### PR TITLE
Add animated in-place photo zoom and remove photo labels

### DIFF
--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -25,7 +25,7 @@ const routes = [
     ...archives.map((entry) => ({ path: `/${locale}/archives/${entry.slug}`, title: `${entry.content[locale].title} — Kwansik Nam`, description: entry.content[locale].summary })),
     { path: `/${locale}/photography/recents`, title: `${photographyLabels[locale].recent} — Kwansik Nam`, description: locale === "ko" ? "최근에 기록한 사진들" : "Recent photographs by Kwansik Nam" },
     ...photoAlbums.map((album) => ({ path: `/${locale}/photography/albums/${album.slug}`, title: `${album.title[locale]} — Kwansik Nam`, description: album.title[locale] })),
-    ...photographs.map((photo) => ({ path: `/${locale}/photography/${photo.slug}`, title: `${photo.location[locale]} — Kwansik Nam`, description: photo.caption?.[locale] ?? photo.alt[locale] })),
+    ...photographs.map((photo) => ({ path: `/${locale}/photography/${photo.slug}`, title: "Photography — Kwansik Nam", description: photo.alt[locale] })),
   ]),
 ];
 

--- a/src/components/PhotoZoom.tsx
+++ b/src/components/PhotoZoom.tsx
@@ -1,0 +1,79 @@
+import { useCallback, useLayoutEffect, useRef, useState } from "react";
+import type { Photograph } from "../content/photography";
+import type { Locale } from "../types/content";
+
+interface PhotoZoomProps {
+  photo: Photograph;
+  source: HTMLImageElement;
+  locale: Locale;
+  onClose: () => void;
+}
+
+export function PhotoZoom({ photo, source, locale, onClose }: PhotoZoomProps) {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const imageRef = useRef<HTMLImageElement>(null);
+  const animationRef = useRef<Animation | null>(null);
+  const closingRef = useRef(false);
+  const [imageUrl, setImageUrl] = useState(source.currentSrc || source.src);
+
+  const originTransform = useCallback(() => {
+    const image = imageRef.current;
+    const dialog = dialogRef.current;
+    if (!image || !dialog) return "none";
+    const origin = source.getBoundingClientRect();
+    const container = dialog.getBoundingClientRect();
+    return `translate(${origin.left - container.left - image.offsetLeft}px, ${origin.top - container.top - image.offsetTop}px) scale(${origin.width / image.offsetWidth}, ${origin.height / image.offsetHeight})`;
+  }, [source]);
+
+  useLayoutEffect(() => {
+    const dialog = dialogRef.current;
+    const image = imageRef.current;
+    if (!dialog || !image) return;
+    const overflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    dialog.showModal();
+    const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    const opening = image.animate([
+      { transform: originTransform() },
+      { transform: "translate(0, 0) scale(1)" },
+    ], { duration: reducedMotion ? 0 : 460, easing: "cubic-bezier(0.22, 1, 0.36, 1)", fill: "both" });
+    animationRef.current = opening;
+    opening.onfinish = () => opening.cancel();
+
+    let active = true;
+    const fullImage = new Image();
+    fullImage.src = photo.image;
+    void fullImage.decode().then(() => { if (active) setImageUrl(photo.image); }).catch(() => {});
+    return () => {
+      active = false;
+      animationRef.current?.cancel();
+      document.body.style.overflow = overflow;
+      dialog.close();
+      source.closest("button")?.focus({ preventScroll: true });
+    };
+  }, [photo.image, source, originTransform]);
+
+  const close = () => {
+    const image = imageRef.current;
+    if (!image || closingRef.current) return;
+    closingRef.current = true;
+    const currentTransform = getComputedStyle(image).transform;
+    const destination = originTransform();
+    animationRef.current?.cancel();
+    const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    const closing = image.animate([
+      { transform: currentTransform },
+      { transform: destination },
+    ], { duration: reducedMotion ? 0 : 360, easing: "cubic-bezier(0.4, 0, 0.2, 1)", fill: "both" });
+    animationRef.current = closing;
+    closing.onfinish = onClose;
+  };
+
+  return <dialog ref={dialogRef} className="photo-lightbox"
+    aria-label={locale === "ko" ? "사진 확대 보기" : "Enlarged photograph"}
+    aria-description={locale === "ko" ? "Esc 키나 사진 바깥 영역을 누르면 닫힙니다." : "Press Escape or click outside the photograph to close."}
+    onCancel={(event) => { event.preventDefault(); close(); }}
+    onClick={(event) => { if (event.target === event.currentTarget) close(); }}>
+    <img ref={imageRef} src={imageUrl} width={photo.width} height={photo.height} alt={photo.alt[locale]} />
+  </dialog>;
+}

--- a/src/pages/PhotoPage.tsx
+++ b/src/pages/PhotoPage.tsx
@@ -7,5 +7,5 @@ import { NotFoundPage } from "./NotFoundPage";
 export function PhotoPage({ locale, slug }: { locale: Locale; slug: string }) {
   const photo = getPhotograph(slug);
   if (!photo) return <NotFoundPage locale={locale} />;
-  return <SiteLayout locale={locale} pageTitle={photo.location[locale]}><article className="photo-detail"><Link className="archive-back" to={`/${locale}/photography`}>← {photographyLabels[locale].back}</Link><img src={photo.image} width={photo.width} height={photo.height} alt={photo.alt[locale]} /><div>{photo.capturedAt && <time dateTime={photo.capturedAt}>{photo.capturedAt}</time>}<p>{photo.location[locale]}</p>{photo.caption && <p>{photo.caption[locale]}</p>}</div></article></SiteLayout>;
+  return <SiteLayout locale={locale} pageTitle="Photography"><article className="photo-detail"><Link className="archive-back" to={`/${locale}/photography`}>← {photographyLabels[locale].back}</Link><img src={photo.image} width={photo.width} height={photo.height} alt={photo.alt[locale]} /></article></SiteLayout>;
 }

--- a/src/pages/PhotographyPage.tsx
+++ b/src/pages/PhotographyPage.tsx
@@ -1,12 +1,14 @@
 import { useEffect, useRef, useState } from "react";
+import { PhotoZoom } from "../components/PhotoZoom";
 import { Link } from "react-router-dom";
-import { getAlbumPhotos, photoAlbums, photographyLabels } from "../content/photography";
+import { getAlbumPhotos, photoAlbums, photographyLabels, type Photograph } from "../content/photography";
 import { ui } from "../content/ui";
 import { SiteLayout } from "../layouts/SiteLayout";
 import type { Locale } from "../types/content";
 import { NotFoundPage } from "./NotFoundPage";
 
 export function PhotographyPage({ locale, recent = false, albumSlug }: { locale: Locale; recent?: boolean; albumSlug?: string }) {
+  const [zoom, setZoom] = useState<{ photo: Photograph; source: HTMLImageElement } | null>(null);
   const galleryRef = useRef<HTMLElement>(null);
   const [photos, setPhotos] = useState(() => getAlbumPhotos(albumSlug));
 
@@ -28,7 +30,7 @@ export function PhotographyPage({ locale, recent = false, albumSlug }: { locale:
     const motion = window.matchMedia("(prefers-reduced-motion: reduce)");
     if (!gallery || motion.matches || !("IntersectionObserver" in window)) return;
 
-    const cards = Array.from(gallery.querySelectorAll<HTMLAnchorElement>("a"));
+    const cards = Array.from(gallery.querySelectorAll<HTMLButtonElement>("button"));
     const reveal = (card: Element) => card.classList.remove("photo-pending");
     const observer = new IntersectionObserver((entries) => {
       for (const entry of entries) {
@@ -48,7 +50,7 @@ export function PhotographyPage({ locale, recent = false, albumSlug }: { locale:
     }
     const revealFocused = (event: FocusEvent) => {
       if (event.target instanceof Element) {
-        const card = event.target.closest("a");
+        const card = event.target.closest("button");
         if (card) { reveal(card); observer.unobserve(card); }
       }
     };
@@ -75,13 +77,17 @@ export function PhotographyPage({ locale, recent = false, albumSlug }: { locale:
         const span = position === 0 || position === 6 ? 7 : position === 1 || position === 5 ? 5 : 4;
         const thumbnailWidth = Math.round(photo.width * Math.min(1, 720 / Math.max(photo.width, photo.height)));
         const mobileWidth = position === 0 ? "calc(100vw - 48px)" : "calc((100vw - 64px) / 2)";
-        return <Link to={`/${locale}/photography/${photo.slug}`} key={photo.slug}>
+        return <button type="button" className={zoom?.photo.slug === photo.slug ? "photo-card photo-zoom-source" : "photo-card"} onClick={(event) => {
+          const source = event.currentTarget.querySelector("img");
+          if (source) setZoom({ photo, source });
+        }} aria-haspopup="dialog" key={photo.slug}>
         <img src={photo.thumbnail ?? photo.image}
           srcSet={photo.thumbnail ? `${photo.thumbnail} ${thumbnailWidth}w, ${photo.image} ${photo.width}w` : undefined}
           sizes={`(max-width: 600px) ${mobileWidth}, (max-width: 800px) ${Math.round(span / 12 * 100)}vw, ${Math.round((800 - 24 * 11) / 12 * span + 24 * (span - 1))}px`}
           width={photo.width} height={photo.height} alt={photo.alt[locale]} loading={index < 3 ? "eager" : "lazy"} decoding="async" />
-      </Link>;
+      </button>;
       })}
     </section>}
+    {zoom && <PhotoZoom photo={zoom.photo} source={zoom.source} locale={locale} onClose={() => setZoom(null)} />}
   </SiteLayout>;
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -107,17 +107,17 @@ img { display: block; max-width: 100%; }
 .empty-state { min-height: 360px; padding-top: var(--space-5); }
 .photo-empty { min-height: 45vh; display: grid; place-items: center; color: var(--color-text-secondary); font-size: 16px; }
 .photo-grid { display: grid; grid-template-columns: repeat(12, minmax(0, 1fr)); align-items: center; gap: 48px 24px; margin-bottom: var(--space-6); }
-.photo-grid a { display: block; min-width: 0; grid-column: span 4; }
-.photo-grid a:nth-child(7n + 1), .photo-grid a:nth-child(7n) { grid-column: span 7; }
-.photo-grid a:nth-child(7n + 2), .photo-grid a:nth-child(7n + 6) { grid-column: span 5; }
+.photo-grid .photo-card { display: block; min-width: 0; grid-column: span 4; }
+.photo-grid .photo-card:nth-child(7n + 1), .photo-grid .photo-card:nth-child(7n) { grid-column: span 7; }
+.photo-grid .photo-card:nth-child(7n + 2), .photo-grid .photo-card:nth-child(7n + 6) { grid-column: span 5; }
+.photo-card { border: 0; padding: 0; background: transparent; cursor: zoom-in; }
 .photo-grid img { width: 100%; height: auto; }
 @media (prefers-reduced-motion: no-preference) {
-  .photo-grid a { transition: opacity 700ms ease-out, transform 700ms cubic-bezier(0.22, 1, 0.36, 1); }
-  .photo-grid a.photo-pending { opacity: 0; transform: translateY(18px); }
+  .photo-grid .photo-card { transition: opacity 700ms ease-out, transform 700ms cubic-bezier(0.22, 1, 0.36, 1); }
+  .photo-grid .photo-card.photo-pending { opacity: 0; transform: translateY(18px); }
 }
 .photo-detail { display: flex; flex-direction: column; gap: var(--space-4); margin: var(--space-5) 0 var(--space-6); }
 .photo-detail > img { width: 100%; height: auto; }
-.photo-detail > div { display: flex; flex-wrap: wrap; gap: var(--space-2) var(--space-3); color: var(--color-text-secondary); font-size: 14px; }
 
 .archive-list { list-style: none; min-height: 360px; margin-bottom: 80px; }
 .archive-entry { display: grid; grid-template-columns: 104px minmax(0, 1fr) 20px; gap: 24px; padding: 32px 0; border-top: 1px solid #e5e5e5; }
@@ -230,8 +230,8 @@ img { display: block; max-width: 100%; }
   .about-hero { margin-top: var(--space-5); }
   .career-year { grid-template-columns: 1fr 8fr; gap: var(--space-5); }
   .photo-grid { gap: 28px 16px; }
-  .photo-grid a:nth-child(n) { grid-column: span 6; }
-  .photo-grid a:nth-child(7n + 1) { grid-column: span 12; }
+  .photo-grid .photo-card:nth-child(n) { grid-column: span 6; }
+  .photo-grid .photo-card:nth-child(7n + 1) { grid-column: span 12; }
   .legacy-project h1 { margin-top: 40px; }
   .legacy-project .contents { gap: 160px; }
   .legacy-project .video_grid { display: flex; overflow-x: scroll; gap: 20px; scrollbar-width: none; }
@@ -245,3 +245,10 @@ img { display: block; max-width: 100%; }
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after { animation-duration: 0.01ms !important; animation-iteration-count: 1 !important; scroll-behavior: auto !important; }
 }
+
+.photo-lightbox { position: fixed; inset: 0; width: 100%; height: 100%; max-width: none; max-height: none; margin: 0; padding: 24px; border: 0; background: transparent; overflow: hidden; }
+.photo-lightbox[open] { display: flex; align-items: center; justify-content: center; }
+.photo-lightbox::backdrop { background: transparent; }
+.photo-lightbox > img { width: auto; height: auto; max-width: 100%; max-height: 100%; object-fit: contain; transform-origin: top left; }
+
+.photo-zoom-source > img { visibility: hidden; }


### PR DESCRIPTION
Clicking a gallery photo now enlarges it in place without navigating. The background remains transparent and there is no close button; Escape or a click outside the photograph animates it back to its original position. Closing restores focus and scroll position while preserving the randomized gallery order.

Removes visible photo dates and titles and uses a generic Photography page title. Image descriptions remain available for accessibility. Zoom uses the loaded thumbnail while the full image decodes and respects reduced-motion preferences.

Validation: npm run check passed with 202 localized routes. Desktop and mobile browser checks passed for enlargement, image fit, transparent backdrop, Escape/outside close, and restoration of focus, scroll position, and order.