### PR TITLE
Fix photo zoom layout shift and mobile dismissal

### DIFF
--- a/src/components/PhotoZoom.tsx
+++ b/src/components/PhotoZoom.tsx
@@ -71,9 +71,13 @@ export function PhotoZoom({ photo, source, locale, onClose }: PhotoZoomProps) {
 
   return <dialog ref={dialogRef} className="photo-lightbox"
     aria-label={locale === "ko" ? "사진 확대 보기" : "Enlarged photograph"}
-    aria-description={locale === "ko" ? "Esc 키나 사진 바깥 영역을 누르면 닫힙니다." : "Press Escape or click outside the photograph to close."}
+    aria-description={locale === "ko" ? "Esc 키나 사진 바깥 영역을 누르면 닫힙니다. 모바일에서는 사진을 눌러도 닫힙니다." : "Press Escape or click outside the photograph to close. On mobile, tap the photograph to close."}
     onCancel={(event) => { event.preventDefault(); close(); }}
-    onClick={(event) => { if (event.target === event.currentTarget) close(); }}>
+    onClick={(event) => {
+      const outsidePhoto = event.target === event.currentTarget;
+      const mobilePhotoTap = event.target === imageRef.current && window.matchMedia("(max-width: 600px)").matches;
+      if (outsidePhoto || mobilePhotoTap) close();
+    }}>
     <img ref={imageRef} src={imageUrl} width={photo.width} height={photo.height} alt={photo.alt[locale]} />
   </dialog>;
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -37,7 +37,7 @@
 }
 
 * { box-sizing: border-box; margin: 0; padding: 0; }
-html { background: #fff; }
+html { background: #fff; scrollbar-gutter: stable; }
 body { min-width: 320px; }
 a { color: inherit; text-decoration: none; }
 a:hover { color: var(--color-accent); }
@@ -252,3 +252,8 @@ img { display: block; max-width: 100%; }
 .photo-lightbox > img { width: auto; height: auto; max-width: 100%; max-height: 100%; object-fit: contain; transform-origin: top left; }
 
 .photo-zoom-source > img { visibility: hidden; }
+
+@media (max-width: 600px) {
+  .photo-lightbox::backdrop { background: rgba(0, 0, 0, 0.72); }
+  .photo-lightbox > img { cursor: zoom-out; }
+}


### PR DESCRIPTION
Reserves scrollbar space so opening and closing a photograph does not shift the gallery horizontally. On screens up to 600px, adds a dimmed backdrop and lets users tap the enlarged photograph to shrink it back. Desktop keeps its transparent backdrop; Escape and outside-click dismissal remain available.

Validation: npm run check passed with 202 localized routes. Browser checks verified stable gallery position and width over three open/close cycles with a 16px scrollbar, plus desktop/mobile backdrop and dismissal behavior.