### PR TITLE
Reduce mobile page gutters to 16px

### DIFF
--- a/src/pages/PhotographyPage.tsx
+++ b/src/pages/PhotographyPage.tsx
@@ -76,7 +76,7 @@ export function PhotographyPage({ locale, recent = false, albumSlug }: { locale:
         const position = index % 7;
         const span = position === 0 || position === 6 ? 7 : position === 1 || position === 5 ? 5 : 4;
         const thumbnailWidth = Math.round(photo.width * Math.min(1, 720 / Math.max(photo.width, photo.height)));
-        const mobileWidth = position === 0 ? "calc(100vw - 48px)" : "calc((100vw - 64px) / 2)";
+        const mobileWidth = position === 0 ? "calc(100vw - 32px)" : "calc((100vw - 48px) / 2)";
         return <button type="button" className={zoom?.photo.slug === photo.slug ? "photo-card photo-zoom-source" : "photo-card"} onClick={(event) => {
           const source = event.currentTarget.querySelector("img");
           if (source) setZoom({ photo, source });

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -215,7 +215,7 @@ img { display: block; max-width: 100%; }
 @keyframes moonSwing { from { transform: rotate(-15deg); } to { transform: rotate(15deg); } }
 
 @media (max-width: 600px) {
-  :root { --navigation-height: 80px; }
+  :root { --navigation-height: 80px; --page-gutter: 16px; }
   .site-shell { margin: 0 var(--page-gutter); }
   .menu { gap: var(--space-4); }
   .archive-entry { grid-template-columns: minmax(0, 1fr) 20px; gap: 12px; }


### PR DESCRIPTION
Changes the shared page gutter from 24px to 16px at mobile widths up to 600px and updates gallery responsive image sizes accordingly. Enlarged-photo horizontal padding remains 8px.

Validation: npm run check passed with 202 localized routes; git diff --check passed.